### PR TITLE
docker-compose.yml and nginx.conf updated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,21 +3,35 @@ version: '3.8'
 services:
   api:
     build: .
+    container_name: api
     command: poetry run gunicorn bbct.wsgi:application --bind 0.0.0.0:8000
-    expose:
-      - 8000
     depends_on:
       - db
     env_file:
       - .env
+    volumes:
+      # Edit the line below to point to your static files directory
+      - static_volume:/home/app/static
+      # End of line
+
+
   nginx:
     build: ./nginx
-    ports:
-      - "8000:80"
     depends_on:
       - api
+    volumes:
+      # Edit the line below to point to your static files directory
+      - static_volume:/home/app/static
+      # End of line, the rest remains same
+      - ./certbot/www:/var/www/certbot/:ro
+      - ./certbot/conf/:/etc/nginx/ssl/:ro
+    ports:
+      - "80:80"
+      - "443:443"
+
+
   db:
-    image: postgres:13.0-alpine
+    image: postgres:13
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     env_file:
@@ -27,5 +41,13 @@ services:
       - POSTGRES_PASSWORD=$DB_PASSWORD
       - POSTGRES_DB=$DB_NAME
 
+  certbot:
+    image: certbot/certbot:latest
+    volumes:
+      - ./certbot/www/:/var/www/certbot/:rw
+      - ./certbot/conf/:/etc/letsencrypt/:rw
+
 volumes:
   postgres_data:
+  certbot:
+  static_volume:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,16 +1,41 @@
-upstream bbct_api {
-    server api:8000;
-}
-
 server {
-
     listen 80;
+    server_name domain_name.com;
 
     location / {
-        proxy_pass http://bbct_api;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
-        proxy_redirect off;
+        return 301 https://$host$request_uri;
     }
-
 }
+
+# server {
+#     listen 443 ssl;
+#     server_name domain_name.com;
+
+#     ssl_certificate /etc/nginx/ssl/live/domain_name.com/fullchain.pem;
+#     ssl_certificate_key /etc/nginx/ssl/live/domain_name.com/privkey.pem;
+
+#     location / {
+#         proxy_pass         http://api:8000;
+#         proxy_redirect     off;
+#         proxy_http_version 1.1;
+#         proxy_cache_bypass $http_upgrade;
+#         proxy_set_header   Upgrade $http_upgrade;
+#         proxy_set_header   Connection keep-alive;
+#         proxy_set_header   Host $host;
+#         proxy_set_header   X-Real-IP $remote_addr;
+#         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header   X-Forwarded-Proto $scheme;
+#         proxy_set_header   X-Forwarded-Host $server_name;
+#         proxy_buffer_size           128k;
+#         proxy_buffers               4 256k;
+#         proxy_busy_buffers_size     256k;
+#     }
+
+#     location /static/ {
+#         alias /home/app/static/;
+#         # Change to the appropriate directory where your static files are stored
+        
+
+#     }
+# }
+


### PR DESCRIPTION
First, notice in the nginx.conf the second server block is commented out. The reason is, in the case you run docker containers for the first time, it will not find the SSL certificate files because it is not generated yet. So, like this (commented out), you have to run containers and run the command `sudo docker compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ -d domain_name.com`. After those files generated , those will be stored in the volume `certbot`. Without deleting this volume folder, cancel the comment part (second server block) and run containers. Then the website should redirect to https and it should work. Hope it helps!